### PR TITLE
Nvidia Runtime Additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ services:
     restart: always
     container_name: channels-dvr
     hostname: channels
+    # When using Nvidia Hardware and docker-compose version 1.29.2 add runtime
+    runtime: nvidia
     image: timstephens24/channels-dvr
     security_opt:
       - seccomp=unconfined
@@ -41,6 +43,7 @@ docker run \
   --restart=always \
   --name=channels-dvr \
   --hostname=channels \
+  --runtime=nvidia \
   --security-opt seccomp=unconfined
   -e PUID=1000 \
   -e PGID=1000 \


### PR DESCRIPTION
I was attempting to migrate my channels-dvr from the fancybits version to this docker version (thanks for migrating this to an LTS version of Ubuntu) and I noticed that the channels would still not recognize the hardware with the following error code `Cannot load libcuda.so.1`. Adding the `runtime: nvidia` to my docker-compose fixed my issue, and I assume it would correct it for others as well.

Thanks!